### PR TITLE
Update abacus_get_data.py and preproces.py to set name of output sub-directories 

### DIFF
--- a/deeph/preprocess/abacus_get_data.py
+++ b/deeph/preprocess/abacus_get_data.py
@@ -58,8 +58,7 @@ class OrbAbacus2DeepH:
         block_rights = block_diag(*[self.get_U(l_right) for l_right in l_rights])
         return block_lefts @ mat @ block_rights.T
 
-
-def abacus_parse(input_path, output_path, only_S=False, get_r=False):
+def abacus_parse(input_path, output_path, data_name, only_S=False, get_r=False):
     input_path = os.path.abspath(input_path)
     output_path = os.path.abspath(output_path)
     os.makedirs(output_path, exist_ok=True)
@@ -77,7 +76,7 @@ def abacus_parse(input_path, output_path, only_S=False, get_r=False):
         log_file_name = "running_get_S.log"
     else:
         log_file_name = "running_scf.log"
-    with open(os.path.join(input_path, "OUT.ABACUS", log_file_name), 'r') as f:
+    with open(os.path.join(input_path, data_name, log_file_name), 'r') as f:
         f.readline()
         line = f.readline()
         assert "WELCOME TO ABACUS" in line
@@ -260,19 +259,20 @@ def abacus_parse(input_path, output_path, only_S=False, get_r=False):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) == 3:
+    if len(sys.argv) == 4:
         only_S = False
         get_r = False
-    elif len(sys.argv) == 4:
-        only_S = bool(int(sys.argv[3]))
-        get_r = False
     elif len(sys.argv) == 5:
-        only_S = bool(int(sys.argv[3]))
-        get_r = bool(int(sys.argv[4]))
+        only_S = bool(int(sys.argv[4]))
+        get_r = False
+    elif len(sys.argv) == 6:
+        only_S = bool(int(sys.argv[4]))
+        get_r = bool(int(sys.argv[5]))
     else:
         raise ValueError("Wrong number of arguments")
     ABACUS_path = sys.argv[1]
     output_path = sys.argv[2]
+    data_name = sys.argv[3]
     print("only_S: {}".format(only_S))
     print("get_r: {}".format(get_r))
-    abacus_parse(ABACUS_path, output_path, only_S, get_r)
+    abacus_parse(ABACUS_path, output_path, data_name, only_S, get_r)

--- a/deeph/scripts/preprocess.py
+++ b/deeph/scripts/preprocess.py
@@ -18,7 +18,7 @@ def main():
 
     raw_dir = os.path.abspath(config.get('basic', 'raw_dir'))
     processed_dir = os.path.abspath(config.get('basic', 'processed_dir'))
-    abacus_suffix = os.path.abspath(config.get('basic', 'abacus_suffix'))
+    abacus_suffix = os.path.abspath(config.get('basic', 'abacus_suffix', fallback='ABACUS'))
     target = config.get('basic', 'target')
     interface = config.get('basic', 'interface')
     local_coordinate = config.getboolean('basic', 'local_coordinate')

--- a/deeph/scripts/preprocess.py
+++ b/deeph/scripts/preprocess.py
@@ -18,6 +18,7 @@ def main():
 
     raw_dir = os.path.abspath(config.get('basic', 'raw_dir'))
     processed_dir = os.path.abspath(config.get('basic', 'processed_dir'))
+    abacus_suffix = os.path.abspath(config.get('basic', 'abacus_suffix'))
     target = config.get('basic', 'target')
     interface = config.get('basic', 'interface')
     local_coordinate = config.getboolean('basic', 'local_coordinate')
@@ -53,7 +54,7 @@ def main():
     abspath_list = []
     for root, dirs, files in os.walk('./'):
         if (interface == 'openmx' and 'openmx.scfout' in files) or (
-            interface == 'abacus' and 'OUT.ABACUS' in dirs) or (
+            interface == 'abacus' and 'OUT.' + abacus_suffix in dirs) or (
             interface == 'siesta' and any(['.HSX' in ifile for ifile in files])) or (
             interface == 'aims' and 'NoTB.dat' in files):
             relpath_list.append(root)
@@ -94,7 +95,7 @@ def main():
             return
 
         if interface == 'abacus':
-            abacus_parse(abspath, os.path.abspath(relpath))
+            abacus_parse(abspath, os.path.abspath(relpath), 'OUT.' + abacus_suffix)
         elif interface == 'siesta':
             siesta_parse(abspath, os.path.abspath(relpath))
         if local_coordinate:


### PR DESCRIPTION
the (name) suffix of the abacus-output-sub-directories can be set in preprocess.ini by ["basic"]["abacus_suffix"]  keyword and not need to be "(OUT.)ABACUS"