### PR TITLE
add: ill_project to python solver

### DIFF
--- a/deeph/inference/dense_calc.jl
+++ b/deeph/inference/dense_calc.jl
@@ -78,8 +78,6 @@ function main()
     println(parsed_args["config"])
     config = JSON.parsefile(parsed_args["config"])
     calc_job = config["calc_job"]
-    ill_project = parsed_args["ill_project"]
-    ill_threshold = parsed_args["ill_threshold"]
 
     if isfile(joinpath(parsed_args["input_dir"],"info.json"))
         spinful = JSON.parsefile(joinpath(parsed_args["input_dir"],"info.json"))["isspinful"]
@@ -150,6 +148,9 @@ function main()
         fermi_level = config["fermi_level"]
         k_data = config["k_data"]
 
+        ill_project = parsed_args["ill_project"] || ("ill_project" in keys(config) && config["ill_project"])
+        ill_threshold = max(parsed_args["ill_threshold"], get(config, "ill_threshold", 0.))
+        
         @info "calculate bands"
         num_ks = k_data2num_ks.(k_data)
         kpaths = k_data2kpath.(k_data)

--- a/deeph/inference/dense_calc.py
+++ b/deeph/inference/dense_calc.py
@@ -182,7 +182,7 @@ if calc_job == "band":
             S_k = (S_k + S_k.getH())/2.
             if ill_project:
                 egval_S, egvec_S = linalg.eig(S_k)
-                project_index = np.argwhere(abs(egval_S)> config["ill_threshold"])
+                project_index = np.argwhere(abs(egval_S)> ill_threshold)
                 if len(project_index) != norbits:
                     # egval_S = egval_S[project_index]
                     egvec_S = np.matrix(egvec_S[:, project_index])


### PR DESCRIPTION
1. fix bug caused by the typo of `site_positions` in `dense_calc.py`
2. add ill projected functional in the python dense calculator.
3. support to read the settings of `ill_projected` and `ill_threshold` from the configure JSON file for both Julia and Python dense calculator.
4. multiprocessing support in dense_calc.py. Use tag `--multiprocessing cpus_needed` or add `"multiprocessing": cpus_meeded` to the JSON file .